### PR TITLE
Don't run `build-dev` on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ workflows:
     - build-dev:
         filters:
           tags:
-            only: /[0-9]+(\.[0-9]+)*/
+            ignore: /.*/
 
     - build-no-dev:
         filters:


### PR DESCRIPTION
## Check-List

_Please make sure to check all of these items:_

- [x] All code style checks passed.
- [x] All unit tests passed.
- [X] The code coverage remains the same or has been increased.

## Description
Avoid run of `build-dev` on tags to save time.

## Related Issues
:heavy_minus_sign:
